### PR TITLE
Use default language URL as fallback for empty social links in other languages

### DIFF
--- a/ps_socialfollow.php
+++ b/ps_socialfollow.php
@@ -384,13 +384,16 @@ class Ps_Socialfollow extends Module implements WidgetInterface
      */
     protected function updateFields()
     {
+        $defaultLanguageId = (int) Configuration::get('PS_LANG_DEFAULT');
         $validator = Validation::createValidator();
         $constraints = [new Url()];
         $values = [];
         $errors = [];
         foreach (static::SOCIAL_NETWORKS as $social) {
+            $defaultValue = trim(Tools::getValue("BLOCKSOCIAL_{$social}_{$defaultLanguageId}", ''));
             foreach (Language::getIDs() as $id_lang) {
-                $values[$social][$id_lang] = trim(Tools::getValue("BLOCKSOCIAL_{$social}_{$id_lang}", ''));
+                $value = trim(Tools::getValue("BLOCKSOCIAL_{$social}_{$id_lang}", ''));
+                $values[$social][$id_lang] = $value ? $value : $defaultValue;
                 $violations = $validator->validate($values[$social][$id_lang], $constraints);
 
                 if (count($violations)) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Add fallback to default language URL for empty social links in other languages
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Idea PrestaShop/Prestashop#39708
| How to test?  | 1. Install at least 2 languages <br/> 2. Enter a social URL only in the default language <br/> 3. Save the configuration <br/> 4. Verify that the value is automatically copied to the other languages

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
