### PR TITLE
Add sortable social fields in module configuration (HelperForm)

### DIFF
--- a/ps_socialfollow.php
+++ b/ps_socialfollow.php
@@ -126,84 +126,17 @@ class Ps_Socialfollow extends Module implements WidgetInterface
 
     public function renderForm()
     {
+        $this->context->controller->addJqueryUI('ui.sortable');
+        $this->context->controller->addJS($this->_path . 'views/js/admin-sortable-fields.js');
+        $this->context->controller->addCSS($this->_path . 'views/css/admin-sortable-fields.css');
+
         $fields_form = [
             'form' => [
                 'legend' => [
                     'title' => $this->trans('Settings', [], 'Admin.Global'),
                     'icon' => 'icon-cogs',
                 ],
-                'input' => [
-                    [
-                        'type' => 'text',
-                        'lang' => true,
-                        'label' => $this->trans('Facebook URL', [], 'Modules.Socialfollow.Admin'),
-                        'name' => 'BLOCKSOCIAL_FACEBOOK',
-                        'desc' => $this->trans('Your Facebook fan page.', [], 'Modules.Socialfollow.Admin'),
-                    ],
-                    [
-                        'type' => 'text',
-                        'lang' => true,
-                        'label' => $this->trans('Twitter URL', [], 'Modules.Socialfollow.Admin'),
-                        'name' => 'BLOCKSOCIAL_TWITTER',
-                        'desc' => $this->trans('Your official Twitter account.', [], 'Modules.Socialfollow.Admin'),
-                    ],
-                    [
-                        'type' => 'text',
-                        'lang' => true,
-                        'label' => $this->trans('RSS URL', [], 'Modules.Socialfollow.Admin'),
-                        'name' => 'BLOCKSOCIAL_RSS',
-                        'desc' => $this->trans('The RSS feed of your choice (your blog, your store, etc.).', [], 'Modules.Socialfollow.Admin'),
-                    ],
-                    [
-                        'type' => 'text',
-                        'lang' => true,
-                        'label' => $this->trans('YouTube URL', [], 'Modules.Socialfollow.Admin'),
-                        'name' => 'BLOCKSOCIAL_YOUTUBE',
-                        'desc' => $this->trans('Your official YouTube account.', [], 'Modules.Socialfollow.Admin'),
-                    ],
-                    [
-                        'type' => 'text',
-                        'lang' => true,
-                        'label' => $this->trans('Pinterest URL:', [], 'Modules.Socialfollow.Admin'),
-                        'name' => 'BLOCKSOCIAL_PINTEREST',
-                        'desc' => $this->trans('Your official Pinterest account.', [], 'Modules.Socialfollow.Admin'),
-                    ],
-                    [
-                        'type' => 'text',
-                        'lang' => true,
-                        'label' => $this->trans('Vimeo URL:', [], 'Modules.Socialfollow.Admin'),
-                        'name' => 'BLOCKSOCIAL_VIMEO',
-                        'desc' => $this->trans('Your official Vimeo account.', [], 'Modules.Socialfollow.Admin'),
-                    ],
-                    [
-                        'type' => 'text',
-                        'lang' => true,
-                        'label' => $this->trans('Instagram URL:', [], 'Modules.Socialfollow.Admin'),
-                        'name' => 'BLOCKSOCIAL_INSTAGRAM',
-                        'desc' => $this->trans('Your official Instagram account.', [], 'Modules.Socialfollow.Admin'),
-                    ],
-                    [
-                        'type' => 'text',
-                        'lang' => true,
-                        'label' => $this->trans('LinkedIn URL:', [], 'Modules.Socialfollow.Admin'),
-                        'name' => 'BLOCKSOCIAL_LINKEDIN',
-                        'desc' => $this->trans('Your official LinkedIn account.', [], 'Modules.Socialfollow.Admin'),
-                    ],
-                    [
-                        'type' => 'text',
-                        'lang' => true,
-                        'label' => $this->trans('TikTok URL:', [], 'Modules.Socialfollow.Admin'),
-                        'name' => 'BLOCKSOCIAL_TIKTOK',
-                        'desc' => $this->trans('Your official TikTok account.', [], 'Modules.Socialfollow.Admin'),
-                    ],
-                    [
-                        'type' => 'text',
-                        'lang' => true,
-                        'label' => $this->trans('Discord URL:', [], 'Modules.Socialfollow.Admin'),
-                        'name' => 'BLOCKSOCIAL_DISCORD',
-                        'desc' => $this->trans('Your official Discord account.', [], 'Modules.Socialfollow.Admin'),
-                    ],
-                ],
+                'input' => $this->getFormInputs(),
                 'submit' => [
                     'title' => $this->trans('Save', [], 'Admin.Global'),
                 ],
@@ -224,9 +157,137 @@ class Ps_Socialfollow extends Module implements WidgetInterface
         return $helper->generateForm([$fields_form]);
     }
 
+    protected function getFormInputs()
+    {
+        $inputs = [
+            [
+                'type' => 'text',
+                'lang' => true,
+                'label' => $this->trans('Facebook URL', [], 'Modules.Socialfollow.Admin'),
+                'name' => 'BLOCKSOCIAL_FACEBOOK',
+                'desc' => $this->trans('Your Facebook fan page.', [], 'Modules.Socialfollow.Admin'),
+            ],
+            [
+                'type' => 'text',
+                'lang' => true,
+                'label' => $this->trans('Twitter URL', [], 'Modules.Socialfollow.Admin'),
+                'name' => 'BLOCKSOCIAL_TWITTER',
+                'desc' => $this->trans('Your official Twitter account.', [], 'Modules.Socialfollow.Admin'),
+            ],
+            [
+                'type' => 'text',
+                'lang' => true,
+                'label' => $this->trans('RSS URL', [], 'Modules.Socialfollow.Admin'),
+                'name' => 'BLOCKSOCIAL_RSS',
+                'desc' => $this->trans('The RSS feed of your choice (your blog, your store, etc.).', [], 'Modules.Socialfollow.Admin'),
+            ],
+            [
+                'type' => 'text',
+                'lang' => true,
+                'label' => $this->trans('YouTube URL', [], 'Modules.Socialfollow.Admin'),
+                'name' => 'BLOCKSOCIAL_YOUTUBE',
+                'desc' => $this->trans('Your official YouTube account.', [], 'Modules.Socialfollow.Admin'),
+            ],
+            [
+                'type' => 'text',
+                'lang' => true,
+                'label' => $this->trans('Pinterest URL:', [], 'Modules.Socialfollow.Admin'),
+                'name' => 'BLOCKSOCIAL_PINTEREST',
+                'desc' => $this->trans('Your official Pinterest account.', [], 'Modules.Socialfollow.Admin'),
+            ],
+            [
+                'type' => 'text',
+                'lang' => true,
+                'label' => $this->trans('Vimeo URL:', [], 'Modules.Socialfollow.Admin'),
+                'name' => 'BLOCKSOCIAL_VIMEO',
+                'desc' => $this->trans('Your official Vimeo account.', [], 'Modules.Socialfollow.Admin'),
+            ],
+            [
+                'type' => 'text',
+                'lang' => true,
+                'label' => $this->trans('Instagram URL:', [], 'Modules.Socialfollow.Admin'),
+                'name' => 'BLOCKSOCIAL_INSTAGRAM',
+                'desc' => $this->trans('Your official Instagram account.', [], 'Modules.Socialfollow.Admin'),
+            ],
+            [
+                'type' => 'text',
+                'lang' => true,
+                'label' => $this->trans('LinkedIn URL:', [], 'Modules.Socialfollow.Admin'),
+                'name' => 'BLOCKSOCIAL_LINKEDIN',
+                'desc' => $this->trans('Your official LinkedIn account.', [], 'Modules.Socialfollow.Admin'),
+            ],
+            [
+                'type' => 'text',
+                'lang' => true,
+                'label' => $this->trans('TikTok URL:', [], 'Modules.Socialfollow.Admin'),
+                'name' => 'BLOCKSOCIAL_TIKTOK',
+                'desc' => $this->trans('Your official TikTok account.', [], 'Modules.Socialfollow.Admin'),
+            ],
+            [
+                'type' => 'text',
+                'lang' => true,
+                'label' => $this->trans('Discord URL:', [], 'Modules.Socialfollow.Admin'),
+                'name' => 'BLOCKSOCIAL_DISCORD',
+                'desc' => $this->trans('Your official Discord account.', [], 'Modules.Socialfollow.Admin'),
+            ],
+            [
+                'type' => 'hidden',
+                'name' => 'BLOCKSOCIAL_FIELDS_ORDER',
+            ],
+        ];
+
+        $inputs = $this->applySocialLinksOrder($inputs, true);
+
+        $inputs[] = [
+            'type' => 'hidden',
+            'name' => 'BLOCKSOCIAL_FIELDS_ORDER',
+        ];
+
+        return $inputs;
+    }
+
+    /**
+     * Applies the saved social links order (BLOCKSOCIAL_FIELDS_ORDER) to either the configuration form inputs
+     * or the front-office social links array, keeping any non-ordered items at the end.
+     */
+    protected function applySocialLinksOrder(array $items, $isAdminForm = false): array
+    {
+        $order = array_values(array_filter(array_map('trim', explode(',', (string) Configuration::get('BLOCKSOCIAL_FIELDS_ORDER')))));
+
+        if (!empty($order)) {
+            $indexed = [];
+            foreach ($items as $index => $item) {
+                $key = $isAdminForm ? (string) ($item['name'] ?? '') : (string) $index;
+                if ($key !== '') {
+                    $indexed[$key] = $item;
+                }
+            }
+
+            $sorted = [];
+
+            foreach ($order as $name) {
+                if ($isAdminForm) {
+                    $name = 'BLOCKSOCIAL_' . strtoupper($name);
+                }
+
+                if (isset($indexed[$name])) {
+                    $sorted[] = $indexed[$name];
+                    unset($indexed[$name]);
+                }
+            }
+
+            $items = array_merge($sorted, array_values($indexed));
+        }
+
+        return $items;
+    }
+
     public function getConfigFieldsValues()
     {
-        $result = [];
+        $result = [
+            'BLOCKSOCIAL_FIELDS_ORDER' => (string) Configuration::get('BLOCKSOCIAL_FIELDS_ORDER'),
+        ];
+
         foreach (static::SOCIAL_NETWORKS as $social) {
             $configuration_name = "BLOCKSOCIAL_$social";
             if (!empty(Configuration::get($configuration_name))) {
@@ -362,6 +423,10 @@ class Ps_Socialfollow extends Module implements WidgetInterface
             ];
         }
 
+        if (!empty($social_links)) {
+            $social_links = $this->applySocialLinksOrder($social_links, false);
+        }
+
         return [
             'social_links' => $social_links,
         ];
@@ -406,6 +471,22 @@ class Ps_Socialfollow extends Module implements WidgetInterface
             foreach (static::SOCIAL_NETWORKS as $social) {
                 Configuration::updateValue("BLOCKSOCIAL_$social", $values[$social]);
             }
+
+            $order = Tools::getValue('BLOCKSOCIAL_FIELDS_ORDER', '');
+
+            if (!empty($order)) {
+                $items = array_filter(array_map('trim', explode(',', $order)));
+
+                $normalized = array_map(function ($item) {
+                    $item = preg_replace('/^BLOCKSOCIAL_/', '', $item);
+
+                    return strtolower($item);
+                }, $items);
+
+                $order = implode(',', $normalized);
+            }
+
+            Configuration::updateValue('BLOCKSOCIAL_FIELDS_ORDER', pSQL($order));
 
             return true;
         }

--- a/ps_socialfollow.php
+++ b/ps_socialfollow.php
@@ -250,14 +250,14 @@ class Ps_Socialfollow extends Module implements WidgetInterface
      * Applies the saved social links order (BLOCKSOCIAL_FIELDS_ORDER) to either the configuration form inputs
      * or the front-office social links array, keeping any non-ordered items at the end.
      */
-    protected function applySocialLinksOrder(array $items, $isAdminForm = false): array
+    protected function applySocialLinksOrder(array $items, $isAdminForm = false)
     {
         $order = array_values(array_filter(array_map('trim', explode(',', (string) Configuration::get('BLOCKSOCIAL_FIELDS_ORDER')))));
 
         if (!empty($order)) {
             $indexed = [];
             foreach ($items as $index => $item) {
-                $key = $isAdminForm ? (string) ($item['name'] ?? '') : (string) $index;
+                $key = $isAdminForm ? (string) (isset($item['name']) ? $item['name'] : '') : (string) $index;
                 if ($key !== '') {
                     $indexed[$key] = $item;
                 }

--- a/views/css/admin-sortable-fields.css
+++ b/views/css/admin-sortable-fields.css
@@ -1,0 +1,15 @@
+#content .form-wrapper > .form-group {
+  position: relative;
+}
+
+#content .form-wrapper .drag-handle {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 2;
+  cursor: move;
+  user-select: none;
+  padding: 4px 8px;
+  line-height: 1;
+  opacity: .6;
+}

--- a/views/js/admin-sortable-fields.js
+++ b/views/js/admin-sortable-fields.js
@@ -1,0 +1,35 @@
+$(function () {
+  var $wrapper = $('#content .form-wrapper');
+
+  if (!$wrapper.length) return;
+
+  $wrapper.find('> .form-group').each(function () {
+    if (!$(this).find('.drag-handle').length) {
+      $(this).prepend('<div class="drag-handle" title="">≡</div>');
+    }
+  });
+
+  $wrapper.sortable({
+    items: '> .form-group',
+    handle: '.drag-handle',
+    axis: 'y',
+    tolerance: 'pointer',
+    cancel: 'input,textarea,select,button,a,.dropdown-menu',
+    update: function () {
+      var order = [];
+
+      $wrapper.find('> .form-group').each(function () {
+        var $input = $(this).find('input[type="text"][id]').first();
+        if (!$input.length) return;
+
+        var id = $input.attr('id');
+        var base = id.replace(/_\d+$/, '');
+        order.push(base);
+      });
+
+      $('input[name="BLOCKSOCIAL_FIELDS_ORDER"]').val(order.join(','));
+    }
+  });
+
+  $wrapper.trigger('sortupdate');
+});


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR introduces drag & drop reordering for social links in the module configuration page.<br/>The order defined in the Back Office is now saved in `BLOCKSOCIAL_FIELDS_ORDER` and consistently applied:<br/>- In the configuration form (HelperForm)<br/>- In the front-office widget rendering<br/><br/>A single internal method handles the ordering logic for both contexts, ensuring consistency and maintainability. 
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | - Drag the social fields to change their position <br/> - Click save <br/> - Verify that the positions are preserved <br/> - Check in the front office that the positions match those set in the admin panel
| Sponsor company   | Codencode snc
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->


### Configuration page – Drag & Drop ordering
<img width="1241" height="1096" alt="Screenshot 2026-02-11 at 12-53-49 Module Manager • Codencode" src="https://github.com/user-attachments/assets/6f7ad54f-b271-4311-976a-cb857ac595a5" />