### PR TITLE
Fix social links keys preservation when applying order

### DIFF
--- a/ps_socialfollow.php
+++ b/ps_socialfollow.php
@@ -271,12 +271,20 @@ class Ps_Socialfollow extends Module implements WidgetInterface
                 }
 
                 if (isset($indexed[$name])) {
-                    $sorted[] = $indexed[$name];
+                    if ($isAdminForm) {
+                        $sorted[] = $indexed[$name];
+                    } else {
+                        $sorted[$name] = $indexed[$name];
+                    }
                     unset($indexed[$name]);
                 }
             }
 
-            $items = array_merge($sorted, array_values($indexed));
+            if ($isAdminForm) {
+                $items = array_merge($sorted, array_values($indexed));
+            } else {
+                $items = $sorted + $indexed;
+            }
         }
 
         return $items;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This pull request fixes a regression introduced by PR : https://github.com/PrestaShop/ps_socialfollow/pull/51<br/>The previous PR introduced social link sorting in the `ps_socialfollow` module. However, during the sorting process, the original associative keys of the `$social_links` array were lost and replaced with numeric keys.<br/>This caused an issue with the Hummingbird theme, whose `ps_socialfollow` template relies on those associative keys to determine which social icon should be displayed:  `{if $key === 'facebook'}` <br/>https://github.com/PrestaShop/hummingbird/blob/7cee7b88910a24470be04fc7953b50056dd024ed/modules/ps_socialfollow/ps_socialfollow.tpl#L14-L34<br/><br/> The Classic theme was not affected because it does not rely on those keys to display the icons.<br/><br/>This change preserves the original social keys when sorting links in the front office, keeping the feature introduced by the previous PR while restoring compatibility with Hummingbird.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Related PR | https://github.com/PrestaShop/ps_socialfollow/pull/51
| How to test?  | 1. Install and enable the Hummingbird theme.<br/>2.  Configure the ps_socialfollow module and fill in several social network links.<br/>3. Change the social links order in the module configuration and save.<br/>4. Go to the front office with Hummingbird enabled.<br/>5. Check that the social links are displayed in the configured order.<br/>6. Check that the correct icon is displayed for each social network.
| Sponsor company   | Codencode snc
<hr>

### Screenshot

**Without PR:**
<img width="1704" height="671" alt="Without PR" src="https://github.com/user-attachments/assets/d762beaa-ddc5-4b22-89b5-5264e566cda2" /><br><br>

**With PR:** 
<br/><img width="1761" height="469" alt="With PR" src="https://github.com/user-attachments/assets/7605456c-665a-41e1-8166-0f5883feda37" />

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
